### PR TITLE
sepolicy: Address powerhal denials & nuke duplicates

### DIFF
--- a/common/vendor/file_contexts
+++ b/common/vendor/file_contexts
@@ -16,6 +16,9 @@
 # RadioConfig HAL
 /(vendor|system/vendor)/bin/hw/android\.hardware\.radio\.config@1\.1-service\.wrapper   u:object_r:hal_radio_config_default_exec:s0
 
+# Power HAL
+/(vendor|system/vendor)/bin/hw/android\.hardware\.power-service\.lineage-libperfmgr u:object_r:hal_power_default_exec:s0
+
 # USB HAL
 /(vendor|system/vendor)/bin/hw/android\.hardware\.usb@1\.3-service\.basic u:object_r:hal_usb_default_exec:s0
 /(vendor|system/vendor)/bin/hw/android\.hardware\.usb@1\.1-service\.typec u:object_r:hal_usb_default_exec:s0

--- a/common/vendor/file_contexts
+++ b/common/vendor/file_contexts
@@ -13,11 +13,11 @@
 # LiveDisplay HAL
 /(vendor|system/vendor)/bin/hw/vendor\.lineage\.livedisplay@2\.0-service-sysfs    u:object_r:hal_lineage_livedisplay_sysfs_exec:s0
 
-# RadioConfig HAL
-/(vendor|system/vendor)/bin/hw/android\.hardware\.radio\.config@1\.1-service\.wrapper   u:object_r:hal_radio_config_default_exec:s0
-
 # Power HAL
 /(vendor|system/vendor)/bin/hw/android\.hardware\.power-service\.lineage-libperfmgr u:object_r:hal_power_default_exec:s0
+
+# RadioConfig HAL
+/(vendor|system/vendor)/bin/hw/android\.hardware\.radio\.config@1\.1-service\.wrapper   u:object_r:hal_radio_config_default_exec:s0
 
 # USB HAL
 /(vendor|system/vendor)/bin/hw/android\.hardware\.usb@1\.3-service\.basic u:object_r:hal_usb_default_exec:s0

--- a/common/vendor/file_contexts
+++ b/common/vendor/file_contexts
@@ -1,9 +1,6 @@
 # Fingerprint HAL
 /(vendor|system/vendor)/bin/hw/android\.hardware\.biometrics\.fingerprint@2\.0-service u:object_r:hal_fingerprint_default_exec:s0
 
-# GNSS HAL
-/(vendor|system/vendor)/bin/hw/android\.hardware\.gnss@1\.0-service\.legacy u:object_r:hal_gnss_default_exec:s0
-
 # Health HAL
 /(vendor|system/vendor)/bin/hw/vendor\.lineage\.health-service\.default u:object_r:hal_lineage_health_default_exec:s0
 
@@ -26,6 +23,3 @@
 
 # Vibrator HAL
 /(vendor|system/vendor)/bin/hw/android\.hardware\.vibrator@1\.0-service\.lineage u:object_r:hal_vibrator_default_exec:s0
-
-# Wi-Fi HAL
-/(vendor|system/vendor)/bin/hw/android\.hardware\.wifi@1\.0-service\.legacy u:object_r:hal_wifi_default_exec:s0

--- a/common/vendor/hal_power_default.te
+++ b/common/vendor/hal_power_default.te
@@ -1,0 +1,7 @@
+# To do powerhint on nodes defined in powerhint.json
+allow hal_power_default cgroup:dir search;
+allow hal_power_default cgroup:file rw_file_perms;
+allow hal_power_default sysfs_devices_system_cpu:file rw_file_perms;
+
+# To get/set powerhal state property
+set_prop(hal_power_default, vendor_power_prop)

--- a/common/vendor/property.te
+++ b/common/vendor/property.te
@@ -1,2 +1,5 @@
 # FM Radio app
 vendor_public_prop(vendor_fm_radio_app_prop);
+
+# Power HAL
+vendor_public_prop(vendor_power_prop);

--- a/common/vendor/property_contexts
+++ b/common/vendor/property_contexts
@@ -1,3 +1,6 @@
 # FM Radio app
 ro.vendor.builtin_fm_antenna_support   u:object_r:vendor_fm_radio_app_prop:s0 exact bool
 ro.vendor.fm.use_audio_session         u:object_r:vendor_fm_radio_app_prop:s0 exact bool
+
+# Power HAL
+vendor.powerhal.                   u:object_r:vendor_power_prop:s0

--- a/common/vendor/vendor_init.te
+++ b/common/vendor/vendor_init.te
@@ -3,3 +3,6 @@ set_prop(vendor_init, vendor_fm_radio_app_prop);
 
 # To set powerhal init property
 set_prop(vendor_init, vendor_power_prop)
+
+# To write to VM nodes
+allow vendor_init proc_dirty:file w_file_perms;

--- a/common/vendor/vendor_init.te
+++ b/common/vendor/vendor_init.te
@@ -1,2 +1,5 @@
 # FM Radio app properties
 set_prop(vendor_init, vendor_fm_radio_app_prop);
+
+# To set powerhal init property
+set_prop(vendor_init, vendor_power_prop)

--- a/qcom/sepolicy.mk
+++ b/qcom/sepolicy.mk
@@ -32,7 +32,10 @@ BOARD_SEPOLICY_M4DEFS += \
     persist_block_device=vendor_persist_block_device \
     qdisplay_service=vendor_qdisplay_service \
     sysfs_battery_supply=vendor_sysfs_battery_supply \
+    sysfs_devfreq=vendor_sysfs_devfreq \
     sysfs_graphics=vendor_sysfs_graphics \
+    sysfs_kgsl=vendor_sysfs_kgsl \
+    sysfs_scsi_host=vendor_sysfs_scsi_host \
     sysfs_socinfo_sensitive=vendor_sysfs_soc_sensitive \
     sysfs_usb_supply=vendor_sysfs_usb_supply
 else

--- a/qcom/vendor/file.te
+++ b/qcom/vendor/file.te
@@ -1,2 +1,1 @@
-type proc_sched_energy_aware, proc_type, fs_type;
 type sysfs_socinfo_sensitive, fs_type, sysfs_type;

--- a/qcom/vendor/file.te
+++ b/qcom/vendor/file.te
@@ -1,1 +1,2 @@
+type proc_sched_energy_aware, proc_type, fs_type;
 type sysfs_socinfo_sensitive, fs_type, sysfs_type;

--- a/qcom/vendor/file_contexts
+++ b/qcom/vendor/file_contexts
@@ -8,4 +8,5 @@
 # Power
 /(vendor|system/vendor)/bin/hw/android\.hardware\.power-service-qti               u:object_r:hal_power_default_exec:s0
 /sys/devices(/platform)?/soc/[a-f0-9]+.qcom,mdss_mdp/idle_state                   u:object_r:sysfs_graphics:s0
+/sys/devices(/platform)?/soc/[a-f0-9]+.ufshc/clkgate_enable                       u:object_r:sysfs_scsi_host:s0
 /sys/devices/virtual/graphics/fb([0-3])+/idle_state                               u:object_r:sysfs_graphics:s0

--- a/qcom/vendor/genfs_contexts
+++ b/qcom/vendor/genfs_contexts
@@ -1,2 +1,2 @@
-genfscon proc /sys/kernel/sched_energy_aware             u:object_r:proc_sched_energy_aware:s0
+genfscon proc /sys/kernel/sched_energy_aware             u:object_r:proc_sched:s0
 genfscon sysfs /devices/soc0/serial_number               u:object_r:sysfs_socinfo_sensitive:s0

--- a/qcom/vendor/genfs_contexts
+++ b/qcom/vendor/genfs_contexts
@@ -1,1 +1,2 @@
+genfscon proc /sys/kernel/sched_energy_aware             u:object_r:proc_sched_energy_aware:s0
 genfscon sysfs /devices/soc0/serial_number               u:object_r:sysfs_socinfo_sensitive:s0

--- a/qcom/vendor/hal_power_default.te
+++ b/qcom/vendor/hal_power_default.te
@@ -1,8 +1,5 @@
-r_dir_file(hal_power_default, sysfs_graphics)
-
 # To do powerhint on nodes defined in powerhint.json
 rw_dir_file(hal_power_default, proc_sched_energy_aware)
-rw_dir_file(hal_power_default, sysfs_devfreq)
 rw_dir_file(hal_power_default, sysfs_devfreq)
 rw_dir_file(hal_power_default, sysfs_graphics)
 rw_dir_file(hal_power_default, sysfs_kgsl)

--- a/qcom/vendor/hal_power_default.te
+++ b/qcom/vendor/hal_power_default.te
@@ -1,5 +1,5 @@
 # To do powerhint on nodes defined in powerhint.json
-rw_dir_file(hal_power_default, proc_sched_energy_aware)
+rw_dir_file(hal_power_default, proc_sched)
 rw_dir_file(hal_power_default, sysfs_devfreq)
 rw_dir_file(hal_power_default, sysfs_graphics)
 rw_dir_file(hal_power_default, sysfs_kgsl)

--- a/qcom/vendor/hal_power_default.te
+++ b/qcom/vendor/hal_power_default.te
@@ -1,1 +1,9 @@
 r_dir_file(hal_power_default, sysfs_graphics)
+
+# To do powerhint on nodes defined in powerhint.json
+rw_dir_file(hal_power_default, proc_sched_energy_aware)
+rw_dir_file(hal_power_default, sysfs_devfreq)
+rw_dir_file(hal_power_default, sysfs_devfreq)
+rw_dir_file(hal_power_default, sysfs_graphics)
+rw_dir_file(hal_power_default, sysfs_kgsl)
+rw_dir_file(hal_power_default, sysfs_scsi_host)


### PR DESCRIPTION
- As few of the old devices still reporting sepolicy denials.